### PR TITLE
TODO-78: 学習セッションの保存時に単語セットNo.が正しく保存されていない 他

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -73,13 +73,13 @@ const datasetMock = {
       "size": 100,
       "wordSets": [
         {
-          "wordSetNo": 1,
+          "wordSetNo": "1",
           "wordSetName": "Part1",
           "filePath": "sample/part1.json",
           "size": 50
         },
         {
-          "wordSetNo": 2,
+          "wordSetNo": "2",
           "wordSetName": "Part2",
           "filePath": "sample/part2.json",
           "size": 50
@@ -136,7 +136,7 @@ import { LS as LSMock } from './store/LS.ts';
 import { HomeScreen as HomeScreenMock } from './HomeScreen/HomeScreen.tsx';
 import { StudyScreen as StudyScreenMock } from './StudyScreen/StudyScreen.tsx';
 import { ResultScreen as ResultScreenMock } from './ResultScreen/ResultScreen.tsx';
-import { WordSetIndexUtil as WordSetIndexUtilMock } from './models/WordSetIndex.ts';
+import { Series, WordSetIndexUtil as WordSetIndexUtilMock } from './models/WordSetIndex.ts';
 import { loadFromWordJson as loadFromWordJsonMock } from './store/WordSetUtils.ts';
 import App from './App';
 import { test } from '@jest/globals';
@@ -222,9 +222,9 @@ test('ホーム画面で単語セットを選択した時にJSONデータが読�
 
 test('問題が正常終了した時に結果画面が表示され、データ保存すること', async () => {
   // ホーム画面に渡っているコールバックを呼び出して、学習画面を表示する
-  const callback1: (_filePath: string) => void = (HomeScreenMock as jest.Mock).mock.calls[0][0].onSelectedWordSet;
+  const callback1: (_series: Series, _filePath: string) => void = (HomeScreenMock as jest.Mock).mock.calls[0][0].onSelectedWordSet;
   await act(async () => {
-    callback1('sample/part2.json');
+    callback1(datasetMock.dataSet[0], 'sample/part2.json');
   });
 
   // StudyScreenに渡っているコールバックを呼び出す
@@ -260,9 +260,9 @@ test('問題が正常終了した時に結果画面が表示され、データ�
 
 test('問題が1問以上解いて中断された時に結果画面が表示され、データ保存すること', async () => {
   // ホーム画面に渡っているコールバックを呼び出して、学習画面を表示する
-  const callback1: (_filePath: string) => void = (HomeScreenMock as jest.Mock).mock.calls[0][0].onSelectedWordSet;
+  const callback1: (_series: Series, _filePath: string) => void = (HomeScreenMock as jest.Mock).mock.calls[0][0].onSelectedWordSet;
   await act(async () => {
-    callback1('sample/part2.json');
+    callback1(datasetMock.dataSet[0], 'sample/part2.json');
   });
 
   // StudyScreenに渡っているコールバックを呼び出す
@@ -285,9 +285,9 @@ test('問題が1問以上解いて中断された時に結果画面が表示さ�
 
 test('問題が1問も解かれずに中断された時に結果画面が表示されずホームに戻ること', async () => {
   // ホーム画面に渡っているコールバックを呼び出して、学習画面を表示する
-  const callback1: (_filePath: string) => void = (HomeScreenMock as jest.Mock).mock.calls[0][0].onSelectedWordSet;
+  const callback1: (_series: Series, _filePath: string) => void = (HomeScreenMock as jest.Mock).mock.calls[0][0].onSelectedWordSet;
   await act(async () => {
-    callback1('sample/part2.json');
+    callback1(datasetMock.dataSet[0], 'sample/part2.json');
   });
 
   // StudyScreenに渡っているコールバックを呼び出す
@@ -308,9 +308,9 @@ test('問題が1問も解かれずに中断された時に結果画面が表示�
 
 test('結果画面でホーム画面に戻るを選択時にホーム画面が表示されること', async () => {
   // ホーム画面に渡っているコールバックを呼び出して、学習画面を表示する
-  const callback1: (_filePath: string) => void = (HomeScreenMock as jest.Mock).mock.calls[0][0].onSelectedWordSet;
+  const callback1: (_series: Series, _filePath: string) => void = (HomeScreenMock as jest.Mock).mock.calls[0][0].onSelectedWordSet;
   await act(async () => {
-    callback1('sample/part2.json');
+    callback1(datasetMock.dataSet[0], 'sample/part2.json');
   });
 
   // StudyScreenに渡っているコールバックを呼び出す
@@ -336,9 +336,9 @@ test('結果画面でホーム画面に戻るを選択時にホーム画面が�
 
 test('結果画面で復習ボタンを選択時に学習画面へ遷移すること', async () => {
   // ホーム画面に渡っているコールバックを呼び出して、学習画面を表示する
-  const callback1: (_filePath: string) => void = (HomeScreenMock as jest.Mock).mock.calls[0][0].onSelectedWordSet;
+  const callback1: (_series: Series, _filePath: string) => void = (HomeScreenMock as jest.Mock).mock.calls[0][0].onSelectedWordSet;
   await act(async () => {
-    callback1('sample/part2.json');
+    callback1(datasetMock.dataSet[0], 'sample/part2.json');
   });
 
   // StudyScreenに渡っているコールバックを呼び出す
@@ -365,9 +365,9 @@ test('結果画面で復習ボタンを選択時に学習画面へ遷移する�
 
 test('結果画面で次のn個へ進むボタンを選択時に学習画面へ遷移すること', async () => {
   // ホーム画面に渡っているコールバックを呼び出して、学習画面を表示する
-  const callback1: (_filePath: string) => void = (HomeScreenMock as jest.Mock).mock.calls[0][0].onSelectedWordSet;
+  const callback1: (_series: Series, _filePath: string) => void = (HomeScreenMock as jest.Mock).mock.calls[0][0].onSelectedWordSet;
   await act(async () => {
-    callback1('sample/part2.json');
+    callback1(datasetMock.dataSet[0], 'sample/part2.json');
   });
 
   // StudyScreenに渡っているコールバックを呼び出す

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,9 +7,8 @@ import { StudyScreen } from './StudyScreen/StudyScreen.tsx';
 import { ResultScreen } from './ResultScreen/ResultScreen.tsx';
 import { createQuiz4 } from './StudyScreen/CreateQuiz.ts';
 import { updateWordStatuses } from './models/WordStatusUtils.ts';
-import { WordSetIndexUtil } from './models/WordSetIndex.ts';
+import { WordSetIndex, WordSetIndexUtil } from './models/WordSetIndex.ts';
 import { Series } from './models/WordSetIndex.ts';
-import { Word } from './models/Word.ts';
 import { UserAnswer } from  './models/Quiz.ts';
 import React from 'react';
 import { StudySet } from './StudySet.ts';
@@ -162,12 +161,12 @@ const App: React.FC = () => {
   };
 
 /* HomeScreenで単語セットが選択されたときの処理
- * - 受け取った単語セットのファイルパスに該当する単語データを読み込む
+ * - 受け取った単語セットに該当する単語データを読み込む
  * - その単語データを元に、学習セット、クイズ、残りの単語を設定する。最後に、学習画面に遷移する
  */
-  const onSelectedWordSet = (filePath: string) => {
+  const onSelectedWordSet = (index: WordSetIndex) => {
     // 単語データの読み込み
-    loadFromWordJson(filePath)
+    loadFromWordJson(index)
       .then(wordSet => {
         const wl = extractFromWords(wordSet, 20, storageData.wordStatus);
         setStudySet(prev => ({
@@ -176,9 +175,10 @@ const App: React.FC = () => {
           quizzes: wl.map(createQuiz4),
           studyMode: 'normal',
           remaining: wordSet.filter(w => !wl.includes(w)),
+          index: index,
         }));
         setCurrentScreen('study');
-        console.info('単語セット選択時の処理が完了', filePath);
+        console.info('単語セット選択時の処理が完了', index.filePath);
       }).catch(console.error);
   };
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -47,6 +47,7 @@ const App: React.FC = () => {
     studyMode: 'normal',
     remaining: [],
     index: null,
+    series: null,
   });
 
   // // 現在の学習セッションで扱っている単語の一覧の中で、まだ出題されていない単語の一覧
@@ -100,7 +101,7 @@ const App: React.FC = () => {
     setStudySet(old => ({...old, quizzes: quizzesInner}));
     setStudyResult(old => ({...old, userAnswers: ua, endOfReason: endOfReason}));
     // setStudySet(studySetInner); // StudySetはそのセットで出題される可能性のあるすべての語。次の20語に進むまで変更しない
-    const saved = save(quizzesInner, ua, storageData, updatedWordsStatuses);
+    const saved = save(quizzesInner, ua, storageData, updatedWordsStatuses, studySet.index!.wordSetNo);
     setStorageData(saved);
 
     setCurrentScreen('result');
@@ -164,7 +165,7 @@ const App: React.FC = () => {
  * - 受け取った単語セットに該当する単語データを読み込む
  * - その単語データを元に、学習セット、クイズ、残りの単語を設定する。最後に、学習画面に遷移する
  */
-  const onSelectedWordSet = (index: WordSetIndex) => {
+  const onSelectedWordSet = (series: Series, index: WordSetIndex) => {
     // 単語データの読み込み
     loadFromWordJson(index)
       .then(wordSet => {
@@ -176,6 +177,7 @@ const App: React.FC = () => {
           studyMode: 'normal',
           remaining: wordSet.filter(w => !wl.includes(w)),
           index: index,
+          series: series,
         }));
         setCurrentScreen('study');
         console.info('単語セット選択時の処理が完了', index.filePath);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -46,10 +46,12 @@ const App: React.FC = () => {
     words: [],
     quizzes: [],
     studyMode: 'normal',
+    remaining: [],
+    index: null,
   });
 
-  // 現在の単語セットで扱っている単語の一覧の中で、まだ出題されていない単語の一覧
-  const [remaining, setRemaining] = useState<Word[]>([]);
+  // // 現在の学習セッションで扱っている単語の一覧の中で、まだ出題されていない単語の一覧
+  // const [remaining, setRemaining] = useState<Word[]>([]);
   
   // 学習画面の終了状況
   const [studyResult, setStudyResult] = useState<StudyResult>({
@@ -58,7 +60,7 @@ const App: React.FC = () => {
   });
 
   // 次のn個へ進むボタンの表示に使用する、次のセッションで学習する単語の数
-  const countOfNext = useMemo(() => remaining.length <= 20 ? remaining.length : 20, [remaining]);
+  const countOfNext = useMemo(() => studySet.remaining.length <= 20 ? studySet.remaining.length : 20, [studySet.remaining]);
 
   // 起動時処理
   useEffect(() => {
@@ -111,7 +113,7 @@ const App: React.FC = () => {
     switch(buttonName) {
       case 'next':
         const extracted = extractFromWords(
-          remaining,
+          studySet.remaining,
           20,
           storageData.wordStatus
         );
@@ -120,8 +122,8 @@ const App: React.FC = () => {
           words: extracted,
           quizzes: extracted.map(createQuiz4),
           studyMode: 'normal',
+          remaining: studySet.remaining.filter(w => !extracted.includes(w)),
         }));
-        setRemaining(remaining.filter(w => !extracted.includes(w)));
         setCurrentScreen('study');
         console.info('次の20語に進むボタンの処理が完了');
         break;
@@ -173,8 +175,8 @@ const App: React.FC = () => {
           words: wl,
           quizzes: wl.map(createQuiz4),
           studyMode: 'normal',
+          remaining: wordSet.filter(w => !wl.includes(w)),
         }));
-        setRemaining(wordSet.filter(w => !wl.includes(w)));
         setCurrentScreen('study');
         console.info('単語セット選択時の処理が完了', filePath);
       }).catch(console.error);

--- a/src/HomeScreen/HomeScreen.test.tsx
+++ b/src/HomeScreen/HomeScreen.test.tsx
@@ -80,6 +80,6 @@ describe('HomeScreen', () => {
   it('GO!ボタンクリック時にonSelectedWordSetが呼ばれること', () => {
     fireEvent.click(screen.getAllByText('GO!')[1]);
     expect(onSelectedWordSet).toHaveBeenCalledTimes(1);
-    expect(onSelectedWordSet).toHaveBeenCalledWith(seriesSet[0].wordSets[1]);
+    expect(onSelectedWordSet).toHaveBeenCalledWith(seriesSet[0], seriesSet[0].wordSets[1]);
   });
 });

--- a/src/HomeScreen/HomeScreen.test.tsx
+++ b/src/HomeScreen/HomeScreen.test.tsx
@@ -80,6 +80,6 @@ describe('HomeScreen', () => {
   it('GO!ボタンクリック時にonSelectedWordSetが呼ばれること', () => {
     fireEvent.click(screen.getAllByText('GO!')[1]);
     expect(onSelectedWordSet).toHaveBeenCalledTimes(1);
-    expect(onSelectedWordSet).toHaveBeenCalledWith('/path/to/wordset2');
+    expect(onSelectedWordSet).toHaveBeenCalledWith(seriesSet[0].wordSets[1]);
   });
 });

--- a/src/HomeScreen/HomeScreen.tsx
+++ b/src/HomeScreen/HomeScreen.tsx
@@ -18,7 +18,7 @@ export type Props = {
    * 単語セットが選択されたときの処理
    * @param filePath 選択された単語セットのファイルパス
    */
-  onSelectedWordSet: (_index: WordSetIndex) => void
+  onSelectedWordSet: (_series: Series, _index: WordSetIndex) => void
 }
 
 /**
@@ -58,9 +58,9 @@ export const HomeScreen: React.FC<Props> = ({seriesSet, wordSetStatus, onSelecte
   //   return wordSetStatusOrdered;
   // }, [seriesSet, wordSetStatus]);
 
-  function onClickGoButton(index: WordSetIndex) {
+  function onClickGoButton(series: Series, index: WordSetIndex) {
     if (onSelectedWordSet) {
-      onSelectedWordSet(index);
+      onSelectedWordSet(series, index);
     }
   }
 
@@ -78,7 +78,7 @@ export const HomeScreen: React.FC<Props> = ({seriesSet, wordSetStatus, onSelecte
                   <li key={index2} className={styles['item']}>
                     <div className={styles['name']}>{wordSet.wordSetName}</div>
                     <div className={styles['size']}>{wordSet.size} Words</div>
-                    <button onClick={() => onClickGoButton(wordSet)} className={styles['button']}>GO!</button>
+                    <button onClick={() => onClickGoButton(series, wordSet)} className={styles['button']}>GO!</button>
                   </li>
                 ))
               }

--- a/src/HomeScreen/HomeScreen.tsx
+++ b/src/HomeScreen/HomeScreen.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Series } from "../models/WordSetIndex";
+import { Series, WordSetIndex } from "../models/WordSetIndex";
 import { LearningInfo } from "../store/LS";
 import styles from "./HomeScreen.module.scss";
 
@@ -18,7 +18,7 @@ export type Props = {
    * 単語セットが選択されたときの処理
    * @param filePath 選択された単語セットのファイルパス
    */
-  onSelectedWordSet: (filePath: string) => void
+  onSelectedWordSet: (_index: WordSetIndex) => void
 }
 
 /**
@@ -58,9 +58,9 @@ export const HomeScreen: React.FC<Props> = ({seriesSet, wordSetStatus, onSelecte
   //   return wordSetStatusOrdered;
   // }, [seriesSet, wordSetStatus]);
 
-  function onClickGoButton(filePath: string) {
+  function onClickGoButton(index: WordSetIndex) {
     if (onSelectedWordSet) {
-      onSelectedWordSet(filePath);
+      onSelectedWordSet(index);
     }
   }
 
@@ -78,7 +78,7 @@ export const HomeScreen: React.FC<Props> = ({seriesSet, wordSetStatus, onSelecte
                   <li key={index2} className={styles['item']}>
                     <div className={styles['name']}>{wordSet.wordSetName}</div>
                     <div className={styles['size']}>{wordSet.size} Words</div>
-                    <button onClick={() => onClickGoButton(wordSet.filePath)} className={styles['button']}>GO!</button>
+                    <button onClick={() => onClickGoButton(wordSet)} className={styles['button']}>GO!</button>
                   </li>
                 ))
               }

--- a/src/ResultScreen/ResultScreen.test.tsx
+++ b/src/ResultScreen/ResultScreen.test.tsx
@@ -17,6 +17,20 @@ describe('ResultScreen 基本項目', () => {
       new Quiz('Word 2', 2, ['option1', 'option2', 'Answer 2']),
     ],
     studyMode: 'normal',
+    index: {
+      wordSetNo: 'test',
+      wordSetName: 'Test',
+      filePath: '/path/to/test.json',
+      size: 20,
+    },
+    remaining: [],
+    series: {
+      seriesNo: 0,
+      seriesDescription: 'Test Series',
+      seriesName: 'TOEIC Service List - Part1',
+      size: 20,
+      wordSets: [],
+    }
   };
   const studyResult: StudyResult = {
     userAnswers: [
@@ -45,7 +59,7 @@ describe('ResultScreen 基本項目', () => {
   });
 
   it('タイトルが描画されること', () => {
-    expect(screen.getByText('TOEIC Service List - Part1')).toBeInTheDocument();
+    expect(screen.getByText(`${studySet.series?.seriesName} - ${studySet.index?.wordSetName}`)).toBeInTheDocument();
   });
 
   it('サブタイトルが描画されること', () => {
@@ -95,6 +109,14 @@ describe('ResultScreen 復習関連', () => {
         new Quiz('Word 2', 2, ['option1', 'option2', 'Answer 2']),
       ],
       studyMode: 'retry',
+      index: {
+        wordSetNo: 'test',
+        wordSetName: 'Test',
+        filePath: '/path/to/test.json',
+        size: 20,
+      },
+      remaining: [],
+      series: null,
     };
     const studyResult: StudyResult = {
       userAnswers: [
@@ -142,6 +164,14 @@ describe('ResultScreen 復習関連', () => {
         new Quiz('Word 2', 2, ['option1', 'option2', 'Answer 2']),
       ],
       studyMode: 'retry',
+      index: {
+        wordSetNo: 'test',
+        wordSetName: 'Test',
+        filePath: '/path/to/test.json',
+        size: 20,
+      },
+      remaining: [],
+      series: null,
     };
 
     const studyResult: StudyResult = {
@@ -187,6 +217,14 @@ describe('ResultScreen 復習関連', () => {
         new Quiz('Word 2', 2, ['option1', 'option2', 'Answer 2']),
       ],
       studyMode: 'retry',
+      index: {
+        wordSetNo: 'test',
+        wordSetName: 'Test',
+        filePath: '/path/to/test.json',
+        size: 20,
+      },
+      remaining: [],
+      series: null,
     };
     const studyResult: StudyResult = {
       userAnswers: [
@@ -253,6 +291,14 @@ describe('ResultScreen 学習結果表示関連', () => {
         new Quiz('Word 12', 1, ['option1', 'option2', 'Answer 12']),
       ],
       studyMode: 'normal',
+      index: {
+        wordSetNo: 'test',
+        wordSetName: 'Test',
+        filePath: '/path/to/test.json',
+        size: 20,
+      },
+      remaining: [],
+      series: null,
     };
     const studyResult: StudyResult = {
       userAnswers: [
@@ -315,6 +361,14 @@ describe('ResultScreen ホームへ戻る関連', () => {
       new Quiz('Word 2', 2, ['option1', 'option2', 'Answer 2']),
     ],
     studyMode: 'normal',
+    index: {
+      wordSetNo: 'test',
+      wordSetName: 'Test',
+      filePath: '/path/to/test.json',
+      size: 20,
+    },
+    remaining: [],
+    series: null,
   };
   const studyResult: StudyResult = {
     userAnswers: [
@@ -360,8 +414,15 @@ describe('ResultScreen 次へ関連', () => {
       new Quiz('Word 2', 2, ['option1', 'option2', 'Answer 2']),
     ],
     studyMode: 'normal',
+    index: {
+      wordSetNo: 'test',
+      wordSetName: 'Test',
+      filePath: '/path/to/test.json',
+      size: 20,
+    },
+    remaining: [],
+    series: null,
   };
-  let userAnswers: UserAnswer[];
   let wordStatus: Record<string, WordStatus>;
   const onUserButtonClick = jest.fn();
 

--- a/src/ResultScreen/ResultScreen.tsx
+++ b/src/ResultScreen/ResultScreen.tsx
@@ -98,7 +98,7 @@ export const ResultScreen: React.FC<Props> = ({ studySet, wordStatus, countOfNex
 
   return (
     <div className={styles['resultScreen']}>
-      <h1 className = {styles['title']} > TOEIC Service List - Part1 </h1>
+      <h1 className = {styles['title']} > {studySet.series?.seriesName} - {studySet.index?.wordSetName} </h1>
       <div className={styles['subTitle']}>{studySet.studyMode === 'retry' ? '復習 ': '通常学習 '} {entries.length}Words</div>
       <div className={styles['subTitle']}>○{countOfCorrect} / ×{countOfIncorrect} / -{countOfSkip}</div>
       <ul className={styles['list']}>

--- a/src/StudyScreen/StudyScreen.test.tsx
+++ b/src/StudyScreen/StudyScreen.test.tsx
@@ -28,6 +28,20 @@ describe('StudyScreen', () => {
       new Quiz('Question 4', 3, ['Option 40', 'Option 41', 'Option 42', 'Option 43']),
       ],
       studyMode: 'normal',
+      index: {
+        wordSetNo: 'test',
+        wordSetName: 'Test',
+        filePath: '/path/to/test.json',
+        size: 20,
+      },
+      remaining: [],
+      series: {
+        seriesNo: 0,
+        seriesDescription: 'Test Series',
+        seriesName: 'TOEIC Service List - Part1',
+        size: 20,
+        wordSets: [],
+      }
     };
 
     render(
@@ -38,6 +52,7 @@ describe('StudyScreen', () => {
     );
     expect(screen.getByText(/^通常学習/)).toBeInTheDocument();
     expect(screen.getByText('Question 1')).toBeInTheDocument();
+    expect(screen.getByText(`${studySet.series?.seriesName} - ${studySet.index?.wordSetName}`)).toBeInTheDocument();
   });
 
   it('復習 問題が正しく表示されること', () => {
@@ -50,6 +65,14 @@ describe('StudyScreen', () => {
         new Quiz('Question 4', 3, ['Option 40', 'Option 41', 'Option 42', 'Option 43']),
       ],
       studyMode: 'retry',
+      index: {
+        wordSetNo: 'test',
+        wordSetName: 'Test',
+        filePath: '/path/to/test.json',
+        size: 20,
+      },
+      remaining: [],
+      series: null,
     };
 
     render(
@@ -72,6 +95,14 @@ describe('StudyScreen', () => {
         new Quiz('Question 4', 3, ['Option 40', 'Option 41', 'Option 42', 'Option 43']),
       ],
       studyMode: 'normal',
+      index: {
+        wordSetNo: 'test',
+        wordSetName: 'Test',
+        filePath: '/path/to/test.json',
+        size: 20,
+      },
+      remaining: [],
+      series: null,
     };
 
     render(
@@ -213,6 +244,14 @@ describe('StudyScreen', () => {
         new Quiz('Question 2', 1, ['Option 20', 'Option 21', 'Option 22', 'Option 23']),
       ],
       studyMode: 'normal',
+      index: {
+        wordSetNo: 'test',
+        wordSetName: 'Test',
+        filePath: '/path/to/test.json',
+        size: 20,
+      },
+      remaining: [],
+      series: null,
     };
 
     render(
@@ -250,6 +289,14 @@ describe('StudyScreen', () => {
         new Quiz('Question 1', 0, ['Option 10', 'Option 11', 'Option 12', 'Option 13']),
       ],
       studyMode: 'normal',
+      index: {
+        wordSetNo: 'test',
+        wordSetName: 'Test',
+        filePath: '/path/to/test.json',
+        size: 20,
+      },
+      remaining: [],
+      series: null,
     };
 
     render(

--- a/src/StudyScreen/StudyScreen.tsx
+++ b/src/StudyScreen/StudyScreen.tsx
@@ -70,7 +70,7 @@ export const StudyScreen: React.FC<StudyScreenProps> = ({ studySet, onEndQuiz })
 
   return (
     <div className={styles['studyScreen']}>
-      <h1 className={styles['title']}>TOEIC Service List - Part1</h1>
+      <h1 className={styles['title']}>{studySet.series?.seriesName} - {studySet.index?.wordSetName}</h1>
       {
         studySet.quizzes.length > 0 && currentQuestionIndex < studySet.quizzes.length &&
         <div>

--- a/src/StudySet.ts
+++ b/src/StudySet.ts
@@ -1,5 +1,6 @@
 import { Quiz } from "./models/Quiz";
 import { Word } from "./models/Word";
+import { WordSetIndex } from "./models/WordSetIndex";
 
 /**
  * アプリの状態を表すデータの一つで、学習セット(学習画面〜リザルト画面で扱う単語や問題のデータ)を表す
@@ -20,4 +21,14 @@ export type StudySet = {
    * 学習モード: 'normal' or 'retry'
    */
   studyMode: 'normal' | 'retry';
+
+  /**
+   * 現在取り組んでいる単語セット情報
+   */
+  index: WordSetIndex | null;
+
+  /**
+   * 未出題の単語の一覧
+   */
+  remaining: Word[];
 };

--- a/src/StudySet.ts
+++ b/src/StudySet.ts
@@ -1,6 +1,6 @@
 import { Quiz } from "./models/Quiz";
 import { Word } from "./models/Word";
-import { WordSetIndex } from "./models/WordSetIndex";
+import { Series, WordSetIndex } from "./models/WordSetIndex";
 
 /**
  * アプリの状態を表すデータの一つで、学習セット(学習画面〜リザルト画面で扱う単語や問題のデータ)を表す
@@ -21,6 +21,11 @@ export type StudySet = {
    * 学習モード: 'normal' or 'retry'
    */
   studyMode: 'normal' | 'retry';
+
+  /**
+   * 現在取り組んでいる学習シリーズ情報
+   */
+  series: Series | null;
 
   /**
    * 現在取り組んでいる単語セット情報

--- a/src/models/LearningSession.ts
+++ b/src/models/LearningSession.ts
@@ -5,7 +5,7 @@ export type AnswerHistoryItem = {
 
 export type LearningSessionCtorParams = {
   sessionId: string;
-  wordSetNo: number;
+  wordSetNo: string;
   completionDate: string;
   answerHistory: AnswerHistoryItem[];
 }
@@ -24,7 +24,7 @@ export class LearningSession {
   /**
    * 単語セットNo
    */
-  wordSetNo: number;
+  wordSetNo: string;
 
   /**
    * 学習完了日時 (format: ISO8601 date-time string)

--- a/src/store/SaveLearningSession.test.ts
+++ b/src/store/SaveLearningSession.test.ts
@@ -32,6 +32,7 @@ describe('save', () => {
     { word: 'word2', status: 2, lastLearnedDate: '', answerHistory: [] },
     { word: 'word3', status: 3, lastLearnedDate: '', answerHistory: [] },
   ];
+  const wordSetNo = 'TestWordSetNo';
 
   beforeEach(() => {
     (LS.save as jest.Mock).mockClear();
@@ -39,12 +40,12 @@ describe('save', () => {
 
   test('学習セッションの状況が正しく保存されること', () => {
     // Act
-    const result = save(quizzes, userAnswers, oldFlashCardData, updatedWordsStatuses);
+    const result = save(quizzes, userAnswers, oldFlashCardData, updatedWordsStatuses, wordSetNo);
 
     // Assert
     expect(result.learningSession).toHaveLength(1);
     expect(result.learningSession[0].sessionId).toBeDefined();
-    expect(result.learningSession[0].wordSetNo).toBe(1);
+    expect(result.learningSession[0].wordSetNo).toBe(wordSetNo);
     expect(result.learningSession[0].completionDate).toBeDefined();
     expect(result.learningSession[0].answerHistory).toHaveLength(3);
     expect(result.learningSession[0].answerHistory[0].w).toBe('word1');
@@ -57,7 +58,7 @@ describe('save', () => {
 
   test('wordStatusが正しく更新されること', () => {
     // Act
-    const result = save(quizzes, userAnswers, oldFlashCardData, updatedWordsStatuses);
+    const result = save(quizzes, userAnswers, oldFlashCardData, updatedWordsStatuses, wordSetNo);
 
     // Assert
     expect(result.wordStatus).toHaveProperty('word1');
@@ -70,7 +71,7 @@ describe('save', () => {
 
   test('wordSetStatusが正しく更新されること', () => {
     // Act
-    const result = save(quizzes, userAnswers, oldFlashCardData, updatedWordsStatuses);
+    const result = save(quizzes, userAnswers, oldFlashCardData, updatedWordsStatuses, wordSetNo);
 
     // Assert
     expect(result.wordSetStatus).toHaveLength(1);
@@ -84,7 +85,7 @@ describe('save', () => {
 
   test('LocalStorageにデータが保存されること', () => {
     // Act
-    save(quizzes, userAnswers, oldFlashCardData, updatedWordsStatuses);
+    const actual = save(quizzes, userAnswers, oldFlashCardData, updatedWordsStatuses, wordSetNo);
 
     // Assert
     expect(LS.save).toHaveBeenCalledWith({
@@ -92,11 +93,13 @@ describe('save', () => {
       wordStatus: expect.any(Object),
       wordSetStatus: expect.any(Array),
     });
+
+    expect(actual.learningSession[0].wordSetNo).toBe(wordSetNo);
   });
 
   test('保存されたデータが返されること', () => {
     // Act
-    const result = save(quizzes, userAnswers, oldFlashCardData, updatedWordsStatuses);
+    const result = save(quizzes, userAnswers, oldFlashCardData, updatedWordsStatuses, wordSetNo);
 
     // Assert
     expect(result).toEqual({

--- a/src/store/SaveLearningSession.ts
+++ b/src/store/SaveLearningSession.ts
@@ -14,19 +14,21 @@ import { FlashCardData, LS } from "./LS";
  * @param updatedWordsStatuses 更新後の単語の学習状況の一覧
  * - updateWordStatusesで作成したものをわたすこと
  * - updateWordStatuses関数の結果は他の箇所でも使いたかったため関数は分離した
+ * @param wordSetNo 学習した単語セットの番号
  * @returns 保存後のデータ
  */
 export function save(
   quizzes: Quiz[],
   userAnswers: UserAnswer[],
   oldFlashCardData: FlashCardData,
-  updatedWordsStatuses: WordStatus[]
+  updatedWordsStatuses: WordStatus[],
+  wordSetNo: string
 ): FlashCardData {
   // 学習セッションの状況
   const learningSessionClone = [...oldFlashCardData.learningSession];
   learningSessionClone.push(new LearningSession({
     sessionId: uuidv4(),
-    wordSetNo: 1, // 仮実装
+    wordSetNo: wordSetNo,
     completionDate: new Date().toISOString(),
     answerHistory: userAnswers.map((answer, index) => {
       return {

--- a/src/store/WordSetUtils.test.ts
+++ b/src/store/WordSetUtils.test.ts
@@ -1,11 +1,17 @@
 import { loadFromWordJson, extractFromWords, getShuffledArray } from './WordSetUtils.ts';
 import { Word } from '../models/Word.ts';
 import { WordStatus } from '../models/WordStatus.ts';
+import { WordSetIndex } from '../models/WordSetIndex.ts';
 
 describe('loadFromWordJson', () => {
   test('JSONファイルから単語データを読み込むこと', async () => {
     // Arrange
-    const jsonFilePath = 'wordlist.json';
+    const index: WordSetIndex = {
+      wordSetNo: '1',
+      wordSetName: 'WordSet1',
+      filePath: 'wordlist.json',
+      size: 3,
+    };
     const expectedWords = [
       { word: 'Word1', quiz: { answer: 'A1', options: ['Opt11', 'Opt12'] } },
       { word: 'Word2', quiz: { answer: 'A2', options: ['Opt21', 'Opt22'] } },
@@ -18,11 +24,11 @@ describe('loadFromWordJson', () => {
     });
 
     // Act
-    const result = await loadFromWordJson(jsonFilePath);
+    const result = await loadFromWordJson(index);
 
     // Assert
     expect(result).toEqual(expectedWords);
-    expect(fetch).toHaveBeenCalledWith('data/' + jsonFilePath);
+    expect(fetch).toHaveBeenCalledWith('data/' + index.filePath);
   });
 });
 

--- a/src/store/WordSetUtils.ts
+++ b/src/store/WordSetUtils.ts
@@ -1,12 +1,14 @@
 import { Word } from '../models/Word.ts';
+import { WordSetIndex } from '../models/WordSetIndex.ts';
 import { WordStatus } from '../models/WordStatus.ts';
 
 /**
  * Jsonファイルから単語を取得し、Wordオブジェクトの配列として返す
+ * @param index 単語セットの目次
  * @return 単語の配列
  */
-export async function loadFromWordJson(jsonFilePath: string): Promise<Word[]> {
-    return  await fetch('data/'+jsonFilePath)
+export async function loadFromWordJson(index: WordSetIndex): Promise<Word[]> {
+    return  await fetch('data/'+index.filePath)
       .then(response => response.json())
       .then(data => data.map(Word.fromObject))
       .catch(error => {


### PR DESCRIPTION
不具合を2件修正

- TODO-78: 学習セッションの保存時に単語セットNo.が正しく保存されていない
- TODO-79: 学習画面、結果画面で、選択した単語セットやシリーズの名称が正しく表示されていない